### PR TITLE
Prepare package for npm publication

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 *.log
 .DS_Store
 node_modules/
+.env*

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+*.log
+.DS_Store
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
+
 - Initial public release
 - Agent skills matrix JSON configuration
 - Skills gate CLI for workflow governance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-02-14
+
+### Added
+- Initial public release
+- Agent skills matrix JSON configuration
+- Skills gate CLI for workflow governance
+- Codex prompts installation script
+- Slash commands: `/ao-start`, `/ao-run`, `/ao-continue`, `/ao-human`, `/ao-gate`, `/ao-matrix`, `/ao-onboard`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2026-02-14
 
+
 ### Added
 - Initial public release
 - Agent skills matrix JSON configuration

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 lvpjsdev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Operational orchestration utilities for agent workflow governance.
 npm install @lvpjsdev/agent-orchestrator
 ```
 
+## Usage
+
+```js
+import matrix from '@lvpjsdev/agent-orchestrator';
+
+console.log(matrix.stages.coder.requiredSkills);
+```
+
+Or import the matrix directly:
+
+```js
+import matrix from '@lvpjsdev/agent-orchestrator/matrix';
+```
+
 ## Source of truth
 
 - `agent-skills-matrix.json` - required/optional/forbidden skills per stage.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# agent-orchestrator
+# @lvpjsdev/agent-orchestrator
 
 Operational orchestration utilities for agent workflow governance.
+
+## Installation
+
+```bash
+npm install @lvpjsdev/agent-orchestrator
+```
 
 ## Source of truth
 
@@ -9,7 +15,7 @@ Operational orchestration utilities for agent workflow governance.
 ## CLI
 
 ```bash
-pnpm -C packages/agent-orchestrator skills:gate -- --matrix ./agent-skills-matrix.json --stage coder --agent claude
+npx @lvpjsdev/agent-orchestrator/cli --matrix ./agent-skills-matrix.json --stage coder --agent claude
 ```
 
 Optional flags:
@@ -28,20 +34,18 @@ npx skills add obra/superpowers@brainstorming -g -y
 
 ## Codex prompts (slash commands)
 
-This repo ships shared Codex prompt files (slash commands) under:
-
-- `packages/agent-orchestrator/prompts/codex/*.md`
+This package ships shared Codex prompt files (slash commands).
 
 Install them into your local Codex prompt directory (usually `~/.codex/prompts`):
 
 ```bash
-pnpm -C packages/agent-orchestrator prompts:install
+npx @lvpjsdev/agent-orchestrator/cli --install-prompts
 ```
 
 Overwrite existing files:
 
 ```bash
-pnpm -C packages/agent-orchestrator prompts:install -- --force
+npx @lvpjsdev/agent-orchestrator/cli --install-prompts --force
 ```
 
 Main workflow prompts:
@@ -57,11 +61,6 @@ Workflow source-of-truth policy:
 - Specs are a secondary reference for anti-drift checks.
 - If PRD and specs diverge, execution follows approved PRD and drift is tagged (recommended: `@spec-drift`).
 
-Git flow policy:
+## License
 
-- `main`: protected production branch, no direct pushes.
-- `develop`: integration branch for test-stand deploy.
-- `feature/<story-id>-<slug>`: one branch per story/task.
-- Each new feature branch must be created with a dedicated worktree.
-- Recommended command:
-  `git worktree add .codex/worktrees/<story-id> -b feature/<story-id>-<slug> develop`
+MIT

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [WORKFLOW_DIAGRAMS.md](docs/WORKFLOW_DIAGRAMS.md) for visual reference.
 ## CLI
 
 ```bash
-npx @lvpjsdev/agent-orchestrator/cli --matrix ./agent-skills-matrix.json --stage coder --agent claude
+npx ao-skills-gate --matrix ./agent-skills-matrix.json --stage coder --agent claude
 ```
 
 Optional flags:
@@ -79,13 +79,13 @@ This repo ships shared Codex prompt files under:
 Install them into your local Codex prompt directory (usually `~/.codex/prompts`):
 
 ```bash
-npx @lvpjsdev/agent-orchestrator/cli --install-prompts
+npx ao-skills-gate --install-prompts
 ```
 
 Overwrite existing files:
 
 ```bash
-npx @lvpjsdev/agent-orchestrator/cli --install-prompts --force
+npx ao-skills-gate --install-prompts --force
 ```
 
 ## Workflow Policies

--- a/matrix.mjs
+++ b/matrix.mjs
@@ -1,0 +1,2 @@
+import matrix from './agent-skills-matrix.json' with { type: 'json' };
+export default matrix;

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.0",
   "description": "Operational orchestration utilities for agent workflow governance",
   "type": "module",
-  "main": "./agent-skills-matrix.json",
+  "main": "./matrix.mjs",
   "exports": {
-    ".": "./agent-skills-matrix.json",
-    "./matrix": "./agent-skills-matrix.json",
+    ".": "./matrix.mjs",
+    "./matrix": "./matrix.mjs",
     "./cli": "./scripts/skills-gate.mjs"
   },
   "files": [
+    "matrix.mjs",
     "agent-skills-matrix.json",
     "scripts/",
     "prompts/"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "./matrix": "./matrix.mjs",
     "./cli": "./scripts/skills-gate.mjs"
   },
+  "bin": {
+    "ao-skills-gate": "./scripts/skills-gate.mjs"
+  },
   "files": [
     "matrix.mjs",
     "agent-skills-matrix.json",
@@ -18,7 +21,7 @@
   "scripts": {
     "skills:gate": "node scripts/skills-gate.mjs",
     "prompts:install": "node scripts/install-codex-prompts.mjs",
-    "prepublishOnly": "node -e \"console.log('Publishing @lvpjsdev/agent-orchestrator...')\""
+    "prepublishOnly": "node --check matrix.mjs && node --check scripts/skills-gate.mjs"
   },
   "keywords": [
     "agent",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,41 @@
 {
-  "name": "@dummy-products/agent-orchestrator",
-  "version": "0.0.0",
-  "private": true,
+  "name": "@lvpjsdev/agent-orchestrator",
+  "version": "0.1.0",
+  "description": "Operational orchestration utilities for agent workflow governance",
   "type": "module",
+  "main": "./agent-skills-matrix.json",
   "exports": {
+    ".": "./agent-skills-matrix.json",
     "./matrix": "./agent-skills-matrix.json",
     "./cli": "./scripts/skills-gate.mjs"
   },
+  "files": [
+    "agent-skills-matrix.json",
+    "scripts/",
+    "prompts/"
+  ],
   "scripts": {
     "skills:gate": "node scripts/skills-gate.mjs",
-    "prompts:install": "node scripts/install-codex-prompts.mjs"
-  }
+    "prompts:install": "node scripts/install-codex-prompts.mjs",
+    "prepublishOnly": "node -e \"console.log('Publishing @lvpjsdev/agent-orchestrator...')\""
+  },
+  "keywords": [
+    "agent",
+    "orchestration",
+    "ai",
+    "workflow",
+    "claude",
+    "codex",
+    "llm"
+  ],
+  "author": "lvpjsdev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lvpjsdev/agent-orchestrator.git"
+  },
+  "bugs": {
+    "url": "https://github.com/lvpjsdev/agent-orchestrator/issues"
+  },
+  "homepage": "https://github.com/lvpjsdev/agent-orchestrator#readme"
 }


### PR DESCRIPTION
## Summary

- Update package name from `@dummy-products/agent-orchestrator` to `@lvpjsdev/agent-orchestrator`
- Remove `private: true` to enable npm publication
- Add package metadata: license, repository, author, keywords
- Add `exports` with default entry point (`.`) for better DX
- Add MIT LICENSE file
- Add CHANGELOG.md for v0.1.0
- Add .npmignore to exclude git files from package
- Update README with npm consumer instructions

## Changes

| File | Change |
|------|--------|
| `package.json` | Name, metadata, exports configuration |
| `LICENSE` | MIT license added |
| `CHANGELOG.md` | Initial changelog v0.1.0 |
| `.npmignore` | Exclude .git, logs, node_modules |
| `README.md` | npm installation and usage instructions |

## Test

```bash
npm pack --dry-run
```

Package size: 8.1 kB (13 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Первый публичный релиз 0.1.0 в npm с CLI-инструментом для проверки навыков и валидации рабочих процессов.
  * Экспорт конфигурации матрицы навыков для прямого использования в приложении.

* **Документация**
  * Обновлён README с установкой и примерами использования (npx/CLI).
  * Добавлен CHANGELOG и LICENSE (MIT).

* **Прочее**
  * Подготовлены файлы для публикации и правила игнорирования пакета (npmignore).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->