### PR TITLE
chore: add Biome for linting and formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "scripts/**/*.mjs", "*.mjs", "esbuild.config.js"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "style": {
+        "useConst": "error",
+        "noParameterAssign": "off",
+        "useTemplate": "warn"
+      },
+      "suspicious": {
+        "noConsole": "off",
+        "noVar": "error"
+      },
+      "complexity": {
+        "noExtraBooleanCast": "warn",
+        "noAdjacentSpacesInRegex": "warn"
+      }
+    }
+  }
+}

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,6 +1,6 @@
-import { build } from 'esbuild';
 import { copyFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { build } from 'esbuild';
 
 const DIST_DIR = resolve('dist');
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,12 @@
   "scripts": {
     "build": "node esbuild.config.js && tsc -p tsconfig.json",
     "prepublishOnly": "npm run build",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint . --write",
+    "format": "biome format . --write",
+    "format:check": "biome format .",
+    "check": "biome check .",
+    "check:fix": "biome check . --write",
     "skills:gate": "node scripts/skills-gate.mjs",
     "prompts:install": "node scripts/install-prompts.mjs --tool codex && node scripts/install-prompts.mjs --tool opencode && node scripts/install-prompts.mjs --tool claude",
     "prompts:install:codex": "node scripts/install-prompts.mjs --tool codex",
@@ -34,6 +40,7 @@
     "prompts:install:global": "node scripts/install-prompts.mjs --tool codex --global && node scripts/install-prompts.mjs --tool opencode --global && node scripts/install-prompts.mjs --tool claude --global"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.15",
     "esbuild": "^0.25.0",
     "typescript": "^5.7.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,386 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.3.15
+        version: 2.3.15
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+packages:
+
+  '@biomejs/biome@2.3.15':
+    resolution: {integrity: sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.3.15':
+    resolution: {integrity: sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.3.15':
+    resolution: {integrity: sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.3.15':
+    resolution: {integrity: sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.3.15':
+    resolution: {integrity: sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.3.15':
+    resolution: {integrity: sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.3.15':
+    resolution: {integrity: sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.3.15':
+    resolution: {integrity: sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.3.15':
+    resolution: {integrity: sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@biomejs/biome@2.3.15':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.3.15
+      '@biomejs/cli-darwin-x64': 2.3.15
+      '@biomejs/cli-linux-arm64': 2.3.15
+      '@biomejs/cli-linux-arm64-musl': 2.3.15
+      '@biomejs/cli-linux-x64': 2.3.15
+      '@biomejs/cli-linux-x64-musl': 2.3.15
+      '@biomejs/cli-win32-arm64': 2.3.15
+      '@biomejs/cli-win32-x64': 2.3.15
+
+  '@biomejs/cli-darwin-arm64@2.3.15':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.3.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.3.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.3.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.3.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.3.15':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.3.15':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.3.15':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  typescript@5.9.3: {}

--- a/scripts/install-prompts.mjs
+++ b/scripts/install-prompts.mjs
@@ -1,34 +1,42 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 function parseArgs(argv) {
   const out = {
     force: false,
     global: false,
-    tool: "",
-    target: "",
+    tool: '',
+    target: '',
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === "--force") {
+    if (arg === '--force') {
       out.force = true;
-    } else if (arg === "--global" || arg === "-g") {
+    } else if (arg === '--global' || arg === '-g') {
       out.global = true;
-    } else if (arg === "--target") {
+    } else if (arg === '--target') {
       const value = argv[i + 1];
-      if (!value || value.startsWith("-")) {
-        throw new Error("Missing value for --target");
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --target');
       }
       out.target = value;
       i += 1;
-    } else if (arg === "--tool") {
+    } else if (arg === '--tool') {
       const value = argv[i + 1];
-      if (!value || value.startsWith("-")) {
-        throw new Error("Missing value for --tool");
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --tool');
       }
       out.tool = value;
       i += 1;
@@ -39,12 +47,12 @@ function parseArgs(argv) {
 
 function getLocalTargetDir(tool) {
   switch (tool) {
-    case "codex":
-      return ".codex/prompts";
-    case "opencode":
-      return ".opencode/skills";
-    case "claude":
-      return ".claude/skills";
+    case 'codex':
+      return '.codex/prompts';
+    case 'opencode':
+      return '.opencode/skills';
+    case 'claude':
+      return '.claude/skills';
     default:
       throw new Error(`Unknown tool: ${tool}. Supported: codex, opencode, claude`);
   }
@@ -52,14 +60,14 @@ function getLocalTargetDir(tool) {
 
 function getGlobalTargetDir(tool) {
   switch (tool) {
-    case "codex": {
-      const codeXHome = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
-      return join(codeXHome, "prompts");
+    case 'codex': {
+      const codeXHome = process.env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+      return join(codeXHome, 'prompts');
     }
-    case "opencode":
-      return join(homedir(), ".config", "opencode", "skills");
-    case "claude":
-      return join(homedir(), ".claude", "skills");
+    case 'opencode':
+      return join(homedir(), '.config', 'opencode', 'skills');
+    case 'claude':
+      return join(homedir(), '.claude', 'skills');
     default:
       throw new Error(`Unknown tool: ${tool}. Supported: codex, opencode, claude`);
   }
@@ -68,9 +76,13 @@ function getGlobalTargetDir(tool) {
 function installCodexPrompts(sourceDir, targetDir, force) {
   mkdirSync(targetDir, { recursive: true });
 
-  const files = readdirSync(sourceDir).filter((name) => name.endsWith(".md"));
+  const files = readdirSync(sourceDir).filter((name) => name.endsWith('.md'));
   if (files.length === 0) {
-    return { installed: [], skipped: [], failed: [{ name: "none", error: "No .md prompts found" }] };
+    return {
+      installed: [],
+      skipped: [],
+      failed: [{ name: 'none', error: 'No .md prompts found' }],
+    };
   }
 
   const installed = [];
@@ -106,7 +118,11 @@ function installSkills(sourceDir, targetDir, force, useSymlinks) {
     .map((entry) => entry.name);
 
   if (skillDirs.length === 0) {
-    return { installed: [], skipped: [], failed: [{ name: "none", error: "No skill directories found" }] };
+    return {
+      installed: [],
+      skipped: [],
+      failed: [{ name: 'none', error: 'No skill directories found' }],
+    };
   }
 
   const installed = [];
@@ -117,9 +133,9 @@ function installSkills(sourceDir, targetDir, force, useSymlinks) {
     const skillSourceDir = join(sourceDir, skillName);
     const skillTargetDir = join(targetDir, skillName);
 
-    const skillFile = join(skillSourceDir, "SKILL.md");
+    const skillFile = join(skillSourceDir, 'SKILL.md');
     if (!existsSync(skillFile)) {
-      failed.push({ name: skillName, error: "No SKILL.md found" });
+      failed.push({ name: skillName, error: 'No SKILL.md found' });
       continue;
     }
 
@@ -168,7 +184,7 @@ function main() {
   }
 
   if (!args.tool) {
-    console.error("Error: --tool is required. Use: codex, opencode, or claude");
+    console.error('Error: --tool is required. Use: codex, opencode, or claude');
     process.exit(2);
   }
 
@@ -186,7 +202,7 @@ function main() {
   }
 
   let result;
-  if (args.tool === "codex") {
+  if (args.tool === 'codex') {
     result = installCodexPrompts(sourceDir, targetDir, args.force);
   } else {
     result = installSkills(sourceDir, targetDir, args.force, !args.global);
@@ -196,7 +212,7 @@ function main() {
     `${JSON.stringify(
       {
         tool: args.tool,
-        scope: args.global ? "global" : "local",
+        scope: args.global ? 'global' : 'local',
         sourceDir,
         targetDir,
         installed: result.installed,
@@ -204,12 +220,12 @@ function main() {
         failed: result.failed,
         note:
           result.skipped.length > 0
-            ? "Some items already existed; re-run with --force to overwrite."
-            : "",
+            ? 'Some items already existed; re-run with --force to overwrite.'
+            : '',
       },
       null,
-      2
-    )}\n`
+      2,
+    )}\n`,
   );
 
   if (result.failed.length > 0) {

--- a/scripts/skills-gate.mjs
+++ b/scripts/skills-gate.mjs
@@ -1,36 +1,36 @@
 #!/usr/bin/env node
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
 
 const SKILL_NAME_RE = /^name:\s*([^\n]+)$/m;
 const QUOTES_TRIM_RE = /^["']|["']$/g;
 
 function parseArgs(argv) {
   const out = {
-    matrix: "",
-    stage: "",
-    agent: "",
-    log: "",
-    policies: "",
+    matrix: '',
+    stage: '',
+    agent: '',
+    log: '',
+    policies: '',
   };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === "--matrix") {
-      out.matrix = argv[i + 1] ?? "";
+    if (arg === '--matrix') {
+      out.matrix = argv[i + 1] ?? '';
       i += 1;
-    } else if (arg === "--stage") {
-      out.stage = argv[i + 1] ?? "";
+    } else if (arg === '--stage') {
+      out.stage = argv[i + 1] ?? '';
       i += 1;
-    } else if (arg === "--agent") {
-      out.agent = argv[i + 1] ?? "";
+    } else if (arg === '--agent') {
+      out.agent = argv[i + 1] ?? '';
       i += 1;
-    } else if (arg === "--log") {
-      out.log = argv[i + 1] ?? "";
+    } else if (arg === '--log') {
+      out.log = argv[i + 1] ?? '';
       i += 1;
-    } else if (arg === "--policies") {
-      out.policies = argv[i + 1] ?? "";
+    } else if (arg === '--policies') {
+      out.policies = argv[i + 1] ?? '';
       i += 1;
     }
   }
@@ -38,28 +38,28 @@ function parseArgs(argv) {
 }
 
 function getSkillDirs() {
-  const codeXHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+  const codeXHome = process.env.CODEX_HOME ?? join(homedir(), '.codex');
   const cwd = process.cwd();
   return [
     ...new Set([
-      join(codeXHome, "skills"),
-      join(homedir(), ".codex", "skills"),
-      join(cwd, ".codex", "skills"),
-      join(cwd, ".agents", "skills"),
-      join(cwd, ".ruler", "skills"),
+      join(codeXHome, 'skills'),
+      join(homedir(), '.codex', 'skills'),
+      join(cwd, '.codex', 'skills'),
+      join(cwd, '.agents', 'skills'),
+      join(cwd, '.ruler', 'skills'),
     ]),
   ];
 }
 
 function getSkillNameFromDir(pathname) {
-  const skillFile = join(pathname, "SKILL.md");
+  const skillFile = join(pathname, 'SKILL.md');
   if (!existsSync(skillFile)) {
     return basename(pathname);
   }
-  const raw = readFileSync(skillFile, "utf8");
+  const raw = readFileSync(skillFile, 'utf8');
   const match = raw.match(SKILL_NAME_RE);
   if (match?.[1]) {
-    return match[1].trim().replace(QUOTES_TRIM_RE, "");
+    return match[1].trim().replace(QUOTES_TRIM_RE, '');
   }
   return basename(pathname);
 }
@@ -91,13 +91,13 @@ function collectInstalledSkills() {
 }
 
 function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function detectSkillsUsed(logText, knownSkills) {
   const used = new Set();
   for (const skill of knownSkills) {
-    const pattern = new RegExp(`(?:\\$|\\\`)?${escapeRegExp(skill)}\\b`, "g");
+    const pattern = new RegExp(`(?:\\$|\\\`)?${escapeRegExp(skill)}\\b`, 'g');
     if (pattern.test(logText)) {
       used.add(skill);
     }
@@ -107,7 +107,7 @@ function detectSkillsUsed(logText, knownSkills) {
 
 function failWithUsage() {
   console.error(
-    "Usage: skills-gate --matrix <path> --stage <stage> [--agent <name>] [--log <path>] [--policies <csv>]"
+    'Usage: skills-gate --matrix <path> --stage <stage> [--agent <name>] [--log <path>] [--policies <csv>]',
   );
   process.exit(2);
 }
@@ -118,7 +118,7 @@ function loadMatrix(matrixPath) {
     process.exit(2);
   }
   try {
-    return JSON.parse(readFileSync(matrixPath, "utf8"));
+    return JSON.parse(readFileSync(matrixPath, 'utf8'));
   } catch (error) {
     console.error(`Failed to parse matrix file: ${matrixPath}`);
     console.error(error);
@@ -128,18 +128,10 @@ function loadMatrix(matrixPath) {
 
 function getStageSkills(stage) {
   return {
-    requiredSkills: Array.isArray(stage.requiredSkills)
-      ? stage.requiredSkills
-      : [],
-    optionalSkills: Array.isArray(stage.optionalSkills)
-      ? stage.optionalSkills
-      : [],
-    forbiddenSkills: Array.isArray(stage.forbiddenSkills)
-      ? stage.forbiddenSkills
-      : [],
-    requiredPolicies: Array.isArray(stage.requiredPolicies)
-      ? stage.requiredPolicies
-      : [],
+    requiredSkills: Array.isArray(stage.requiredSkills) ? stage.requiredSkills : [],
+    optionalSkills: Array.isArray(stage.optionalSkills) ? stage.optionalSkills : [],
+    forbiddenSkills: Array.isArray(stage.forbiddenSkills) ? stage.forbiddenSkills : [],
+    requiredPolicies: Array.isArray(stage.requiredPolicies) ? stage.requiredPolicies : [],
   };
 }
 
@@ -148,24 +140,16 @@ function parseCsv(value) {
     return [];
   }
   return value
-    .split(",")
+    .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
 }
 
-function collectReasons(
-  requiredSkills,
-  requiredPolicies,
-  installedSkills,
-  stage,
-  args
-) {
+function collectReasons(requiredSkills, requiredPolicies, installedSkills, stage, args) {
   const reasons = [];
-  const skillsMissing = requiredSkills.filter(
-    (name) => !installedSkills.includes(name)
-  );
+  const skillsMissing = requiredSkills.filter((name) => !installedSkills.includes(name));
   if (skillsMissing.length > 0) {
-    reasons.push(`missing required skills: ${skillsMissing.join(", ")}`);
+    reasons.push(`missing required skills: ${skillsMissing.join(', ')}`);
   }
 
   const allowedAgents = Array.isArray(stage?.agentConstraints?.allowedAgents)
@@ -174,21 +158,17 @@ function collectReasons(
   if (allowedAgents.length > 0) {
     if (!args.agent) {
       reasons.push(
-        `agent is required for stage '${args.stage}' (allowed: ${allowedAgents.join(", ")})`
+        `agent is required for stage '${args.stage}' (allowed: ${allowedAgents.join(', ')})`,
       );
     } else if (!allowedAgents.includes(args.agent)) {
-      reasons.push(
-        `agent '${args.agent}' is not allowed for stage '${args.stage}'`
-      );
+      reasons.push(`agent '${args.agent}' is not allowed for stage '${args.stage}'`);
     }
   }
 
   const providedPolicies = parseCsv(args.policies);
-  const policiesMissing = requiredPolicies.filter(
-    (name) => !providedPolicies.includes(name)
-  );
+  const policiesMissing = requiredPolicies.filter((name) => !providedPolicies.includes(name));
   if (policiesMissing.length > 0) {
-    reasons.push(`missing required policies: ${policiesMissing.join(", ")}`);
+    reasons.push(`missing required policies: ${policiesMissing.join(', ')}`);
   }
   return { reasons, skillsMissing, providedPolicies, policiesMissing };
 }
@@ -210,53 +190,41 @@ function main() {
   const { requiredSkills, optionalSkills, forbiddenSkills, requiredPolicies } =
     getStageSkills(stage);
   const installedSkills = collectInstalledSkills();
-  const { reasons, skillsMissing, providedPolicies, policiesMissing } =
-    collectReasons(
-      requiredSkills,
-      requiredPolicies,
-      installedSkills,
-      stage,
-      args
-    );
+  const { reasons, skillsMissing, providedPolicies, policiesMissing } = collectReasons(
+    requiredSkills,
+    requiredPolicies,
+    installedSkills,
+    stage,
+    args,
+  );
 
   let skillsUsed = [];
   let forbiddenSkillsUsed = [];
   const warnings = [];
   const allKnownSkills = [
-    ...new Set([
-      ...installedSkills,
-      ...requiredSkills,
-      ...optionalSkills,
-      ...forbiddenSkills,
-    ]),
+    ...new Set([...installedSkills, ...requiredSkills, ...optionalSkills, ...forbiddenSkills]),
   ];
   if (!args.log) {
     if (forbiddenSkills.length > 0) {
-      warnings.push(
-        "forbidden skills usage check skipped: pass --log <path> to enable detection"
-      );
+      warnings.push('forbidden skills usage check skipped: pass --log <path> to enable detection');
     }
   } else if (existsSync(args.log)) {
-    const logText = readFileSync(args.log, "utf8");
+    const logText = readFileSync(args.log, 'utf8');
     skillsUsed = detectSkillsUsed(logText, allKnownSkills);
-    forbiddenSkillsUsed = skillsUsed.filter((name) =>
-      forbiddenSkills.includes(name)
-    );
+    forbiddenSkillsUsed = skillsUsed.filter((name) => forbiddenSkills.includes(name));
     if (forbiddenSkillsUsed.length > 0) {
-      reasons.push(`forbidden skills used: ${forbiddenSkillsUsed.join(", ")}`);
+      reasons.push(`forbidden skills used: ${forbiddenSkillsUsed.join(', ')}`);
     }
   } else {
-    warnings.push(
-      `log file not found: ${args.log}; forbidden skills usage check skipped`
-    );
+    warnings.push(`log file not found: ${args.log}; forbidden skills usage check skipped`);
   }
 
-  const status = reasons.length === 0 ? "pass" : "blocked";
+  const status = reasons.length === 0 ? 'pass' : 'blocked';
   const result = {
     matrixVersion: matrix?.version ?? 1,
     stage: args.stage,
     label: stage.label ?? args.stage,
-    agent: args.agent || "",
+    agent: args.agent || '',
     status,
     skillGateStatus: status,
     requiredSkills,
@@ -273,7 +241,7 @@ function main() {
     warnings,
   };
 
-  const exitCode = status === "pass" ? 0 : 1;
+  const exitCode = status === 'pass' ? 0 : 1;
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`, () => {
     process.exit(exitCode);
   });


### PR DESCRIPTION
## Summary

- Add Biome as replacement for ESLint/Prettier (faster, unified tool)
- Configure formatting per AGENTS.md style guide: 2 spaces, single quotes, 100 char line width
- Auto-format existing code with Biome
- Add npm scripts: `lint`, `lint:fix`, `format`, `format:check`, `check`, `check:fix`

## Changes

| File | Change |
|------|--------|
| `biome.json` | New config file |
| `package.json` | Add @biomejs/biome, add scripts |
| `esbuild.config.js` | Auto-format imports |
| `scripts/*.mjs` | Auto-format (quotes, formatting) |

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm check` passes
- [x] `pnpm build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Chores**
  * Добавлена конфигурация Biome для форматирования и проверки кода
  * Добавлены новые npm-скрипты: lint, lint:fix, format, format:check, check, check:fix

* **Style**
  * Обновлено форматирование кода в скриптах проекта

<!-- end of auto-generated comment: release notes by coderabbit.ai -->